### PR TITLE
Fix percentage encoding bug in SVG screenshots

### DIFF
--- a/resources/app.js
+++ b/resources/app.js
@@ -51,7 +51,10 @@
 
   async function toSvg() {
     const data = await domtoimage.toSvg(contentNode);
-    return data.replace(/%0A/g, "\n");
+    return data
+      .replace(/%0A/g, "\n")
+      .replace(/#/g, '%23')
+      .replace(/%/g, "%25");
   }
 
   async function downloadImage() {

--- a/resources/app.js
+++ b/resources/app.js
@@ -53,8 +53,8 @@
     const data = await domtoimage.toSvg(contentNode);
     return data
       .replace(/%0A/g, "\n")
-      .replace(/#/g, '%23')
-      .replace(/%/g, "%25");
+      .replace(/%23/g, '#')
+      .replace(/%25/g, "%");
   }
 
   async function downloadImage() {


### PR DESCRIPTION
During the XHTML conversion process, the characters `%25` and %23 get encoded as well.
Let's decode these to fix # and % in SVG screenshots.

Refs: https://github.com/1904labs/dom-to-image-more/blob/v2.9.1/src/dom-to-image-more.js#L623